### PR TITLE
Make module independent of stdio

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,5 +10,25 @@ const prettyReplUnsupported = () => require('repl');
 const prettyReplNode12 = () => require('./lib/pretty-repl-compat');
 const prettyRepl = () => require('./lib/pretty-repl');
 
-module.exports = (process.stdout.isTTY !== true || semver.lt(process.version, '11.0.0')) ? prettyReplUnsupported()
+const impl = (tty) => (!tty || semver.lt(process.version, '11.0.0')) ? prettyReplUnsupported()
   : semver.lt(process.version, '13.0.0') ? prettyReplNode12() : prettyRepl();
+
+function isReplTerminal(options) {
+  if (options.terminal !== undefined)
+    return options.terminal;
+  return (options.output || process.stdout).isTTY;
+}
+
+class REPLServer extends (prettyReplUnsupported().REPLServer) {
+  constructor(options = {}) {
+    return new (impl(isReplTerminal(options)).REPLServer)(options);
+  }
+}
+function start(options = {}) {
+  return impl(isReplTerminal(options)).start(options);
+}
+
+module.exports = {
+  REPLServer,
+  start
+};

--- a/lib/highlight.js
+++ b/lib/highlight.js
@@ -4,7 +4,7 @@ const emphasize = require('emphasize');
 const chalk = require('chalk');
 
 const windows = process.platform === 'win32';
-const sheet = {
+const sheet = (chalk) => ({
   comment: chalk.gray,
   quote: chalk.gray,
 
@@ -39,7 +39,15 @@ const sheet = {
   emphasis: chalk.italic,
   strong: chalk.bold,
   formula: chalk.inverse
-};
+});
 
-module.exports = (s) =>
-  emphasize.highlight('js', s, sheet).value;
+module.exports = (stream) => {
+  let level = 0;
+  if (stream.isTTY) {
+    if (stream.getColorDepth() >= 4) level = 1;
+    if (stream.getColorDepth() >= 8) level = 2;
+    if (stream.getColorDepth() >= 24) level = 3;
+  }
+  const colorSheet = sheet(new chalk.Instance({ level }));
+  return (s) => emphasize.highlight('js', s, colorSheet).value;
+};

--- a/lib/pretty-repl-compat.js
+++ b/lib/pretty-repl-compat.js
@@ -6,9 +6,6 @@ const highlight = require('./highlight');
 const originalWriteToOutput = Interface.prototype._writeToOutput;
 const originalInsertString = Interface.prototype._insertString;
 
-let ansiCursor;
-let colorize = str => highlight(str);
-
 Interface.prototype._writeToOutput = function (stringToWrite) {
   // If this particular instance does not have the `__pretty` flag
   // just call the original implementation of `_writeToOutput`.
@@ -32,14 +29,14 @@ Interface.prototype._writeToOutput = function (stringToWrite) {
 };
 
 Interface.prototype.renderCurrentLine = function (stringToWrite) {
-  if (!ansiCursor) {
+  if (!this.ansiCursor) {
     return;
   }
   const promptLength = this._prompt.length;
   const cursorPos = this._getCursorPos();
   const nX = cursorPos.cols;
-  ansiCursor.horizontalAbsolute(promptLength + 1).eraseLine().write(colorize(stringToWrite));
-  ansiCursor.horizontalAbsolute(nX);
+  this.ansiCursor.horizontalAbsolute(promptLength + 1).eraseLine().write(this.colorize(stringToWrite));
+  this.ansiCursor.horizontalAbsolute(nX);
 };
 
 Interface.prototype._insertString = function (c) {
@@ -65,17 +62,15 @@ Interface.prototype._insertString = function (c) {
 module.exports = {
   REPLServer: repl.REPLServer,
   start: (prompt, source, eval_, useGlobal, ignoreUndefined, replMode) => {
-    if (prompt && prompt.colorize) {
-      colorize = prompt.colorize;
-    }
-    ansiCursor = ansi(prompt.output || process.stdout);
     const replInstance = repl.start(prompt, source, eval_, useGlobal, ignoreUndefined, replMode);
+    replInstance.colorize = (prompt && prompt.colorize) || highlight(prompt.output || process.stdout);
+    replInstance.ansiCursor = ansi(prompt.output || process.stdout);
     replInstance.__pretty = true;
     // For some reason, tests fail if we don't initialize line to be the empty string.
     // Specifically, `REPLServer.Interface.getCursorPos()` finds itself in a state where `line`
     // is undefined.
     replInstance.line = '';
+    replInstance.__prettyModuleLoaded = __filename;
     return replInstance;
-  },
-  _moduleLoaded: __filename
+  }
 };

--- a/lib/pretty-repl.js
+++ b/lib/pretty-repl.js
@@ -5,16 +5,15 @@ const ansi = require('ansi');
 class PrettyREPLServer extends repl.REPLServer {
   constructor (options = {}) {
     super(options);
-    this.colorize = (options && options.colorize) || function (str) {
-      return highlight(str);
-    };
     options.output = options.output || process.stdout;
+    this.colorize = (options && options.colorize) || highlight(options.output);
     this.ansiCursor = ansi(options.output);
 
     // For some reason, tests fail if we don't initialize line to be the empty string.
     // Specifically, `REPLServer.Interface.getCursorPos()` finds itself in a state where `line`
     // is undefined.
     this.line = '';
+    this.__prettyModuleLoaded = __filename;
   }
 
   _writeToOutput (stringToWrite) {
@@ -62,9 +61,8 @@ class PrettyREPLServer extends repl.REPLServer {
 }
 
 module.exports = {
-  PrettyREPLServer,
+  REPLServer: PrettyREPLServer,
   start: options => {
     return new PrettyREPLServer(options);
-  },
-  _moduleLoaded: __filename
+  }
 };

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,6 +1,7 @@
 const test = require('tape');
 const { stdio } = require('stdio-mock');
 const decache = require('decache');
+const { PassThrough } = require('stream');
 
 const nodeMajorVersion = () => {
   const versionMatcher = process.version.match(/^v(\d{1,2})\.\d{1,2}\.\d{1,2}$/);
@@ -12,12 +13,14 @@ test('loads the right module for the version of node', t => {
   process.stdout.isTTY = true;
   const repl = require('..');
   const major = nodeMajorVersion();
+  const { stdin, stdout } = stdio();
+  const prettyRepl = repl.start({ input: stdin, output: stdout, terminal: true });
   if (major >= 13) {
-    t.ok(repl._moduleLoaded.endsWith('pretty-repl.js'), 'pretty-repl loaded');
+    t.ok(prettyRepl.__prettyModuleLoaded.endsWith('pretty-repl.js'), 'pretty-repl loaded');
   } else if (major < 13 && major >= 11) {
-    t.ok(repl._moduleLoaded.endsWith('pretty-repl-compat.js'), 'pretty-repl-compat (compatibility mode for old node versions) loaded');
+    t.ok(prettyRepl.__prettyModuleLoaded.endsWith('pretty-repl-compat.js'), 'pretty-repl-compat (compatibility mode for old node versions) loaded');
   } else {
-    t.notOk(repl._moduleLoaded, 'pretty-repl not loaded (old version of node)');
+    t.notOk(prettyRepl.__prettyModuleLoaded, 'pretty-repl not loaded (old version of node)');
   }
   decache('..');
 });
@@ -53,7 +56,8 @@ test('applies colors when necesssary', t => {
     prompt: 'test-prompt > ',
     input: stdin,
     output: stdout,
-    colorize: str => str.replace(/const/, '<color>const</color>')
+    colorize: str => str.replace(/const/, '<color>const</color>'),
+    terminal: true
   });
   let out = '';
   stdout.on('data', data => {
@@ -85,6 +89,32 @@ test('does not apply colors when not necesssary', t => {
     out += data;
     if (out.endsWith('\n')) {
       t.equal(out, 'test-prompt > let foo = 12\n', 'output is not colored');
+    }
+  });
+  prettyRepl._writeToOutput('test-prompt > let foo = 12\n');
+  decache('..');
+});
+
+test('picks colors independently of stdio', {
+  skip: nodeMajorVersion() < 12
+}, t => {
+  t.plan(1);
+  process.stdout.isTTY = undefined;
+  const repl = require('..');
+  const { stdin } = stdio();
+  const output = new PassThrough();
+  output.isTTY = true;
+  output.getColorDepth = () => 8;
+  const prettyRepl = repl.start({
+    prompt: 'test-prompt > ',
+    input: stdin,
+    output: output
+  });
+  let out = '';
+  output.setEncoding('utf8').on('data', data => {
+    out += data;
+    if (out.endsWith('\n')) {
+      t.match(out, /(\x1b\[.*m)+let(\x1b\[.*m)+ foo = (\x1b\[.*m)+12(\x1b\[.*m)+/, 'output is colored');
     }
   });
   prettyRepl._writeToOutput('test-prompt > let foo = 12\n');


### PR DESCRIPTION
Do not hardcode dependencies on stdio streams, when those might
not actually end up being the input/output streams:

- Pick the right module at REPL creation time based on the options
  passed to the REPL start function, rather than at startup
- Pass options to chalk that are based on the TTY color support
  (because otherwise chalk would also determine color support at
  startup)
- Do not use global ansiCursor / colorize variables in the Node.js 12.x
  variant